### PR TITLE
[v2.0.3] Expose ES ssl config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.2",
+    "version": "2.0.3",
     "name": "saman-jafari/telescope-elasticsearch-driver",
     "description": "it will allow you to switch from sql database to elasticsearch as driver for your data storage and it will eliminate the deadlock so it makes telescope a ready for production logging system.",
     "keywords": [

--- a/config/config.php
+++ b/config/config.php
@@ -5,4 +5,10 @@ return [
     'username' => env('TELESCOPE_ELASTICSEARCH_USERNAME', ''),
     'password' => env('TELESCOPE_ELASTICSEARCH_PASSWORD', ''),
     'index'    => env('TELESCOPE_ELASTICSEARCH_INDEX', 'telescope'),
+    'ssl' => [
+        'verify' => env('TELESCOPE_ELASTICSEARCH_SSL_CA', null),
+        'cert'   => env('TELESCOPE_ELASTICSEARCH_SSL_CERT', null),
+        'ssl_key'    => env('TELESCOPE_ELASTICSEARCH_SSL_KEY', null),
+        'ssl_verification' => env('TELESCOPE_ELASTICSEARCH_SSL_VERIFICATION', true),
+    ]
 ];

--- a/src/TelescopeIndex.php
+++ b/src/TelescopeIndex.php
@@ -31,10 +31,26 @@ class TelescopeIndex
     {
         $this->index = config('telescope-elasticsearch-driver.index');
         try {
-            $this->client = ClientBuilder::create()
+            $builder = ClientBuilder::create()
                 ->setHosts([config('telescope-elasticsearch-driver.host')])
-                ->setBasicAuthentication(config('telescope-elasticsearch-driver.username'), config('telescope-elasticsearch-driver.password'))
-                ->build();
+                ->setBasicAuthentication(
+                    config('telescope-elasticsearch-driver.username'),
+                    config('telescope-elasticsearch-driver.password')
+                );
+
+            $sslVerification = config('telescope-elasticsearch-driver.ssl.ssl_verification');
+            $builder->setSSLVerification($sslVerification);
+
+            $sslOptions = collect(config('telescope-elasticsearch-driver.ssl'))
+                ->except('ssl_verification')
+                ->filter()
+                ->toArray();
+
+            if (!empty($sslOptions)) {
+                $builder->setHttpClientOptions($sslOptions);
+            }
+
+            $this->client = $builder->build();
         } catch (AuthenticationException $e) {
             Log::error('auth failure', ['message' => $e->getMessage()]);
         }


### PR DESCRIPTION
Allow applications to configure the ssl settings in the elasticsearch driver.

When using self signed certificates, ssl verification needs to be disabled.